### PR TITLE
Add merge_label_maps utility

### DIFF
--- a/Repo/scripts/merge_label_maps.py
+++ b/Repo/scripts/merge_label_maps.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+# Run this after executing find_missing_vals.py to update the label map.
+"""Merge label maps after running find_missing_vals.py."""
+import json
+from pathlib import Path
+
+# Resolve base paths relative to repo root
+BASE = Path(__file__).resolve().parent.parent.parent / "WikiData.nosync"
+FULL_MAP = BASE / "label_map_full.json"
+FOUND_MAP = BASE / "missing_found.json"
+OUT_PATH = BASE / "label_map_complete.json"
+
+
+def main():
+    # load existing full map and the newly found labels
+    with open(FULL_MAP, "r", encoding="utf-8") as f:
+        full = json.load(f)
+    with open(FOUND_MAP, "r", encoding="utf-8") as f:
+        found = json.load(f)
+
+    # merge maps giving precedence to newly found labels
+    full.update(found)
+
+    # write the combined map back out
+    with open(OUT_PATH, "w", encoding="utf-8") as f:
+        json.dump(full, f, ensure_ascii=False, indent=2)
+    print(f"✅ Wrote merged label map to {OUT_PATH}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a script to merge label maps after recovering missing labels

## Testing
- `python3 -m py_compile Repo/scripts/merge_label_maps.py`


------
https://chatgpt.com/codex/tasks/task_e_68550fb1fdd083329dc20dec4f8a7b51