### PR TITLE
Fix decode script to unescape labels

### DIFF
--- a/Repo/scripts/decode_label_map.py
+++ b/Repo/scripts/decode_label_map.py
@@ -11,6 +11,12 @@ def main():
     with open(IN_FILE, "r", encoding="utf-8") as f:
         data = json.load(f)
 
+    def decode_label(text: str) -> str:
+        """Decode escape sequences like \\uXXXX into real characters."""
+        return text.encode("utf-8").decode("unicode_escape")
+
+    data = {k: decode_label(v) for k, v in data.items()}
+
     with open(OUT_FILE, "w", encoding="utf-8") as f:
         json.dump(data, f, ensure_ascii=False, indent=2)
     print(f"Decoded labels written to {OUT_FILE}")


### PR DESCRIPTION
## Summary
- decode unicode escape sequences when generating label map

## Testing
- `python -m py_compile Repo/scripts/decode_label_map.py`
- `python Repo/scripts/decode_label_map.py` *(fails: FileNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_685515f3647883329c22f2a20c3c524d