### PR TITLE
Add CLI option to decode script

### DIFF
--- a/Repo/scripts/decode_descriptions.py
+++ b/Repo/scripts/decode_descriptions.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 import sqlite3
 from pathlib import Path
+import argparse
 
 BASE = Path(__file__).resolve().parent.parent.parent / "WikiData.nosync"
 DB_PATH = BASE / "wikidata_labeled.db"
@@ -11,8 +12,10 @@ def decode_text(text: str) -> str:
     return text.encode("utf-8").decode("unicode_escape")
 
 
-def main():
-    conn = sqlite3.connect(DB_PATH)
+def main(db_path: Path = DB_PATH):
+    """Decode escape sequences in the description property."""
+
+    conn = sqlite3.connect(db_path)
     cur = conn.cursor()
 
     cur.execute("SELECT rowid, value FROM properties_labeled WHERE pid='description'")
@@ -32,8 +35,16 @@ def main():
 
     conn.commit()
     conn.close()
-    print(f"\u2705 Decoded {count} descriptions in {DB_PATH}")
+    print(f"\u2705 Decoded {count} descriptions in {db_path}")
 
 
 if __name__ == "__main__":
-    main()
+    parser = argparse.ArgumentParser(description="Decode description texts")
+    parser.add_argument(
+        "--db",
+        type=Path,
+        default=DB_PATH,
+        help="Path to SQLite database",
+    )
+    args = parser.parse_args()
+    main(args.db)


### PR DESCRIPTION
## Summary
- switch decode_descriptions to allow `--db` path override
- minor refactor to support the new option

## Testing
- `python3 -m py_compile Repo/scripts/decode_descriptions.py`

------
https://chatgpt.com/codex/tasks/task_e_68552dadf07483328f1751a2debff798