### PR TITLE
Fix sql_to_text output

### DIFF
--- a/Repo/scripts/sql_to_text.py
+++ b/Repo/scripts/sql_to_text.py
@@ -4,7 +4,8 @@
 For each QID listed in a text file this script builds a short text of the
 form::
 
-    qid_label, description
+    qid | qid_label
+    description
     "Attributes include:"
     property_label: value_label
     ...
@@ -66,8 +67,11 @@ def build_text(qid: str, rows: list[tuple[str | None, str | None, str | None]]) 
             if prop_label and val_label:
                 attributes.append(f"{prop_label}: {val_label}")
 
-    headline = f"{qlabel}, {description}".strip().strip(",")
-    lines = [headline, "Attributes include:"]
+    headline = f"{qid} | {qlabel}".strip()
+    lines = [headline]
+    if description:
+        lines.append(description)
+    lines.append("Attributes include:")
     lines.extend(attributes)
     return "\n".join(lines)
 


### PR DESCRIPTION
## Summary
- update documentation of `sql_to_text.py` for new text format
- output now includes `qid | qid_label` headline
- description is printed on its own line

## Testing
- `python Repo/scripts/sql_to_text.py --db Repo/scripts/test_wikidata.db --qids Repo/scripts/subset_qids.txt --out temp.db` *(fails: no rows generated)*

------
https://chatgpt.com/codex/tasks/task_e_6857333787608332bf66b391579d653f