### PR TITLE
Add notebook for simple data analysis

### DIFF
--- a/Repo/notebooks/data_visualization.ipynb
+++ b/Repo/notebooks/data_visualization.ipynb
@@ -1,0 +1,85 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fabf8054",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "import json\n",
+    "from collections import Counter\n",
+    "from pathlib import Path\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "# Path to the file mapping QIDs to PIDs\n",
+    "facts_file = Path('human_facts.json')  # adjust the path as needed\n",
+    "\n",
+    "with open(facts_file, 'r', encoding='utf-8') as f:\n",
+    "    human_facts = json.load(f)\n",
+    "\n",
+    "# Number of PIDs for each QID\n",
+    "pid_counts = [len(props) for props in human_facts.values()]\n",
+    "\n",
+    "# Display distribution\n",
+    "count_freq = Counter(pid_counts)\n",
+    "print('Distribution of PIDs per QID:')\n",
+    "for n, c in sorted(count_freq.items()):\n",
+    "    print(f'{n}: {c}')\n",
+    "\n",
+    "# Histogram with 1-2, 3-4, ... bins\n",
+    "max_count = max(pid_counts)\n",
+    "bins = range(0, max_count + 2, 2)\n",
+    "plt.hist(pid_counts, bins=bins, edgecolor='black')\n",
+    "plt.xlabel('Number of PIDs per QID (binned by 2)')\n",
+    "plt.ylabel('Number of QIDs')\n",
+    "plt.title('Distribution of PIDs linked to QIDs')\n",
+    "plt.xticks([b+1 for b in bins])\n",
+    "plt.show()\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ca29d334",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "import json\n",
+    "from datetime import datetime\n",
+    "from statistics import mean, median\n",
+    "from pathlib import Path\n",
+    "\n",
+    "# Path to cleaned death dates\n",
+    "path = Path('death_dates_clean.json')  # adjust the path as needed\n",
+    "\n",
+    "with open(path, 'r', encoding='utf-8') as f:\n",
+    "    death_dates = json.load(f)\n",
+    "\n",
+    "# Parse dates and convert to ordinal for calculations\n",
+    "ordinals = [datetime.fromisoformat(date).toordinal() for date in death_dates.values()]\n",
+    "\n",
+    "mean_date = datetime.fromordinal(int(mean(ordinals)))\n",
+    "median_date = datetime.fromordinal(int(median(ordinals)))\n",
+    "\n",
+    "print('Mean death date:', mean_date.date())\n",
+    "print('Median death date:', median_date.date())\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- add a new `data_visualization.ipynb` notebook with code for PID distribution and death date statistics

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'transformers')*

------
https://chatgpt.com/codex/tasks/task_e_685bf70eb3f8833293630d55050f221a