### PR TITLE
Add notebook for simple data analysis

### DIFF
--- a/Repo/notebooks/data_visualization.ipynb
+++ b/Repo/notebooks/data_visualization.ipynb
@@ -1,0 +1,102 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3058895c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import json\n",
+    "from pathlib import Path\n",
+    "from collections import Counter\n",
+    "from datetime import datetime\n",
+    "from statistics import mean, median\n",
+    "import matplotlib.pyplot as plt"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "20fa1229",
+   "metadata": {},
+   "source": [
+    "This notebook visualizes how many property IDs (PIDs) each entity (QID) has."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9b07b3b3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "BASE = Path(__file__).resolve().parent.parent.parent / 'WikiData.nosync'\n",
+    "facts_file = BASE / 'human_facts.json'\n",
+    "\n",
+    "with open(facts_file, 'r', encoding='utf-8') as f:\n",
+    "    human_facts = json.load(f)\n",
+    "\n",
+    "# count PIDs per QID\n",
+    "pid_counts = [len(props) for props in human_facts.values()]\n",
+    "\n",
+    "# frequency distribution\n",
+    "count_freq = Counter(pid_counts)\n",
+    "print('Distribution of PIDs per QID:')\n",
+    "for n, c in sorted(count_freq.items()):\n",
+    "    print(f'{n}: {c}')\n",
+    "\n",
+    "# plot histogram with bins [1-2], [3-4], ...\n",
+    "max_count = max(pid_counts)\n",
+    "bins = range(0, max_count + 2, 2)\n",
+    "plt.hist(pid_counts, bins=bins, edgecolor='black')\n",
+    "plt.xlabel('Number of PIDs per QID (binned by 2)')\n",
+    "plt.ylabel('Number of QIDs')\n",
+    "plt.title('Distribution of PIDs linked to QIDs')\n",
+    "plt.xticks([b+1 for b in bins])\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9c485cca",
+   "metadata": {},
+   "source": [
+    "The next cell reads `death_dates_clean.json` and computes the mean and median death dates."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "dc5c36eb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "BASE = Path(__file__).resolve().parent.parent.parent / 'WikiData.nosync'\n",
+    "death_file = BASE / 'death_dates_clean.json'\n",
+    "\n",
+    "with open(death_file, 'r', encoding='utf-8') as f:\n",
+    "    death_dates = json.load(f)\n",
+    "\n",
+    "# convert ISO date strings to ordinal numbers for statistics\n",
+    "ordinals = [datetime.fromisoformat(date).toordinal() for date in death_dates.values()]\n",
+    "mean_date = datetime.fromordinal(int(mean(ordinals)))\n",
+    "median_date = datetime.fromordinal(int(median(ordinals)))\n",
+    "print('Mean death date:', mean_date.date())\n",
+    "print('Median death date:', median_date.date())"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- update `data_visualization.ipynb`
  - gather imports in a single cell
  - explain each step with markdown
  - use `BASE` path to access dataset files

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'transformers')*

------
https://chatgpt.com/codex/tasks/task_e_685bf70eb3f8833293630d55050f221a