### PR TITLE
Add data visualization notebook

### DIFF
--- a/Repo/notebooks/data_visualization.ipynb
+++ b/Repo/notebooks/data_visualization.ipynb
@@ -1,0 +1,99 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "bc7e8a2a",
+   "metadata": {},
+   "source": [
+    "# Data Visualization\n",
+    "\n",
+    "Import necessary libraries and define paths to the data files."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f0bf4ec9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "import sqlite3\n",
+    "import pandas as pd\n",
+    "import matplotlib.pyplot as plt\n",
+    "import json\n",
+    "import numpy as np\n",
+    "\n",
+    "BASE = Path().parent.parent.parent / \"WikiData.nosync\"\n",
+    "DB_PATH = BASE / \"wikidata_labeled_wo.db\"\n",
+    "DEATH_PATH = BASE / \"death_dates_clean.json"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4184a320",
+   "metadata": {},
+   "source": [
+    "## Distribution of PIDs per QID\n",
+    "\n",
+    "This block loads the SQLite database, counts how many property IDs (PIDs) are associated with each QID and plots the distribution. PIDs counts are grouped in pairs (1–2, 3–4, etc.)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "96f7beed",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "conn = sqlite3.connect(DB_PATH)\n",
+    "query = \"SELECT qid, COUNT(pid) as pid_count FROM properties_labeled GROUP BY qid\"\n",
+    "df = pd.read_sql_query(query, conn)\n",
+    "conn.close()\n",
+    "\n",
+    "df['bucket'] = ((df['pid_count'] - 1) // 2) * 2 + 1\n",
+    "bucket_counts = df['bucket'].value_counts().sort_index()\n",
+    "\n",
+    "plt.figure(figsize=(8,4))\n",
+    "plt.bar([f\"{b}-{b+1}\" for b in bucket_counts.index], bucket_counts.values)\n",
+    "plt.xlabel('PID count range')\n",
+    "plt.ylabel('Number of QIDs')\n",
+    "plt.title('Distribution of PIDs per QID')\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a6dc23b8",
+   "metadata": {},
+   "source": [
+    "## Statistics of Death Dates\n",
+    "\n",
+    "This block reads `death_dates_clean.json` and calculates the median and mean of the death dates."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a5a4947d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with open(DEATH_PATH, 'r', encoding='utf-8') as f:\n",
+    "    death_data = json.load(f)\n",
+    "\n",
+    "dates = pd.to_datetime(list(death_data.values()), errors='coerce').dropna()\n",
+    "\n",
+    "median_date = dates.median()\n",
+    "mean_date = dates.mean()\n",
+    "\n",
+    "print(f\"Median death date: {median_date.date()}\")\n",
+    "print(f\"Mean death date: {mean_date.date()}\")"
+   ]
+  }
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- add a Jupyter notebook for visualizing dataset distributions

## Testing
- `python -m nbformat Repo/notebooks/data_visualization.ipynb`

------
https://chatgpt.com/codex/tasks/task_e_685d0c2875d0833287f44551fc55d300