### PR TITLE
Add notebook for DB and embedding visualization

### DIFF
--- a/Repo/notebooks/db_and_embed_visualization.ipynb
+++ b/Repo/notebooks/db_and_embed_visualization.ipynb
@@ -1,0 +1,117 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "32b594a5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "from pathlib import Path\n",
+    "import sqlite3\n",
+    "import subprocess\n",
+    "\n",
+    "BASE = Path.cwd().parent.parent / 'WikiData.nosync'\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "45264734",
+   "metadata": {},
+   "source": [
+    "### Query wikidata_labeled_wo.db\n",
+    "\n",
+    "Connects to the labeled database and returns the row where the QID is Q42."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7536c5dd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "path = BASE / 'wikidata_labeled_wo.db'\n",
+    "with sqlite3.connect(path) as conn:\n",
+    "    cur = conn.cursor()\n",
+    "    cur.execute(\"SELECT * FROM texts WHERE qid='Q42';\")\n",
+    "    rows = cur.fetchall()\n",
+    "    for row in rows:\n",
+    "        print(row)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a399ce38",
+   "metadata": {},
+   "source": [
+    "### Query qid_texts_wo_clean.db\n",
+    "\n",
+    "Looks up the entry for Q42 in the cleaned text database."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "feac8f56",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "path = BASE / 'qid_texts_wo_clean.db'\n",
+    "with sqlite3.connect(path) as conn:\n",
+    "    cur = conn.cursor()\n",
+    "    cur.execute(\"SELECT * FROM texts WHERE qid='Q42';\")\n",
+    "    rows = cur.fetchall()\n",
+    "    for row in rows:\n",
+    "        print(row)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "98bdb70b",
+   "metadata": {},
+   "source": [
+    "### Inspect people_embeddings_test.h5\n",
+    "\n",
+    "Uses `h5dump` to display the first embedding vector and associated metadata."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d9494623",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "path = BASE / 'people_embeddings_test.h5'\n",
+    "cmds = [\n",
+    "    ['h5dump', '-d', '/embeddings', '-s', '0,0', '-c', '1,1024', str(path)],\n",
+    "    ['h5dump', '-d', '/qids', '-s', '0', '-c', '1', str(path)],\n",
+    "    ['h5dump', '-d', '/dob', '-s', '0', '-c', '1', str(path)],\n",
+    "    ['h5dump', '-d', '/dob_year', '-s', '0', '-c', '1', str(path)]\n",
+    "]\n",
+    "for cmd in cmds:\n",
+    "    result = subprocess.run(cmd, text=True, capture_output=True)\n",
+    "    print(' '.join(cmd))\n",
+    "    print(result.stdout)\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- add `db_and_embed_visualization.ipynb` under `Repo/notebooks`
- show example SQL queries and `h5dump` commands for inspecting data files

## Testing
- `pip3 install nbformat`


------
https://chatgpt.com/codex/tasks/task_e_685d4398be708332aeac89defa88506d