### PR TITLE
Add models notebook for baseline ML

### DIFF
--- a/Repo/notebooks/models.ipynb
+++ b/Repo/notebooks/models.ipynb
@@ -1,0 +1,108 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8ae84a28",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "import h5py\n",
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "from sklearn.model_selection import train_test_split\n",
+    "from sklearn.linear_model import LinearRegression\n",
+    "from sklearn.metrics import mean_squared_error\n",
+    "\n",
+    "BASE = Path.cwd().parent.parent / 'WikiData.nosync'\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1699dfea",
+   "metadata": {},
+   "source": [
+    "## Load embeddings and check for missing values\n",
+    "This block loads the HDF5 database containing the embeddings and ensures there are no missing values for the year of death."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ff2dfed3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "h5_path = BASE / 'people_embeddings_death10k.h5'\n",
+    "with h5py.File(h5_path, 'r') as h5:\n",
+    "    embeddings = h5['embeddings'][:]\n",
+    "    qids = h5['qids'][:].astype(str)\n",
+    "    dod_year = h5['dod_year'][:]\n",
+    "\n",
+    "mask = ~np.isnan(dod_year)\n",
+    "print('Missing years:', np.sum(~mask))\n",
+    "embeddings = embeddings[mask]\n",
+    "qids = qids[mask]\n",
+    "dod_year = dod_year[mask]\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "79e31c7f",
+   "metadata": {},
+   "source": [
+    "## Split into train, validation and test sets\n",
+    "Adjust the fractions below to control how much data goes into each split."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2659926d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "train_frac = 0.7\n",
+    "val_frac = 0.15\n",
+    "test_frac = 0.15\n",
+    "\n",
+    "X_temp, X_test, y_temp, y_test = train_test_split(\n",
+    "    embeddings, dod_year, test_size=test_frac, random_state=42)\n",
+    "val_ratio = val_frac / (train_frac + val_frac)\n",
+    "X_train, X_val, y_train, y_val = train_test_split(\n",
+    "    X_temp, y_temp, test_size=val_ratio, random_state=42)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f746dbb5",
+   "metadata": {},
+   "source": [
+    "## Baseline Linear Regression\n",
+    "Fit a simple linear regression model and evaluate it on the validation and test sets."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "33bfdbc3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "lr = LinearRegression()\n",
+    "lr.fit(X_train, y_train)\n",
+    "val_pred = lr.predict(X_val)\n",
+    "val_mse = mean_squared_error(y_val, val_pred)\n",
+    "print(f'Validation MSE: {val_mse:.2f}')\n",
+    "\n",
+    "test_pred = lr.predict(X_test)\n",
+    "test_mse = mean_squared_error(y_test, test_pred)\n",
+    "print(f'Test MSE: {test_mse:.2f}')\n"
+   ]
+  }
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- add `models.ipynb` for experimenting with ML models on the embedding database

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_685e8a4fddd883328933e21c461ccf79